### PR TITLE
Fix deployment to publish correct url

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,23 @@ There is a Dockerfile to simplify deployment. So the steps to get the website wo
 
 `docker run --volume="$PWD:/srv/jekyll" -p 4000:4000 -t kbss-website`
 
-3. The website is now available at `http://localhost:4000`
+3. The website is now available at `http://localhost:4000/kbss-website`
+
+
+### Docker compose
+
+1. Build the Docker image
+
+`docker-compose build`
+
+2. [Optional] Configure environment variables for docker-compose file, e.g.:
+`echo BASENAME=/kbss-website > .env`
+
+3. Run the container.
+
+`docker-compose up -d`
+
+3. The website is now available at `http://localhost:4000/kbss-website`
 
 ### Without Docker
 
@@ -35,5 +51,5 @@ Assuming Jekyll is installed on the system, the following commands can be used t
 
 `jekyll serve`
 
-3. The website is now available at `http://localhost:4000`
+3. The website is now available at `http://localhost:4000/kbss-website`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  kbss-website:
+    build:
+      context: .
+    container_name: kbss-website
+    restart: always
+    ports:
+      - "4000:4000"
+    volumes:
+      - $PWD:/srv/jekyll

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: .
     container_name: kbss-website
+    command: ["jekyll", "serve", "--host", "0.0.0.0", "--basename", "${BASENAME:-/kbss-website}"]
     restart: always
     ports:
       - "4000:4000"


### PR DESCRIPTION
Not sure who broke the build at KBSS. There were local changes in `kbss-website/_config.yml` which got lost and thus deployment stopped working.

More concretely _config.yml contained configuration:
`baseurl                  : "/web"`

which were reverted back to :
`baseurl                  : "/kbss-website"`


In order to mitigate this I added BASEURL parameter to related docker-compose.yml file. I left default value of BASEURL "/kbss-website".