### PR TITLE
Fix GH action creating open-mic announcement file into wrong directory

### DIFF
--- a/.github/workflows/open-mic-announcement-post.yml
+++ b/.github/workflows/open-mic-announcement-post.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Create announcement post from template
       run: |
         TITLE_ID=$(echo ${{ github.event.inputs.open_mic_session_title }} | sed 's/ /-/g' | tr [A-Z] [a-z])
-        cp ./_drafts/open-mic-announcement-template.markdown  ./_drafts/${{ github.event.inputs.open_mic_session_date }}-${TITLE_ID}-announcement.markdown
+        cp ./_drafts/open-mic-announcement-template.markdown  ./_posts/${{ github.event.inputs.open_mic_session_date }}-${TITLE_ID}-announcement.markdown
     - name: Commit changes
       run: |
         git add .


### PR DESCRIPTION
Fix location where new markdown files are created by GH action. Instead of `_drafts` it should be created in `_posts`